### PR TITLE
allow both base64 and base64url encoded public keys

### DIFF
--- a/jwt-wallet.go
+++ b/jwt-wallet.go
@@ -8,9 +8,9 @@ import (
 	"hash"
 	"strings"
 
-	"github.com/cosmos/btcutil/bech32"
 	"github.com/FigureTechnologies/kong-jwt-wallet/grants"
 	"github.com/FigureTechnologies/kong-jwt-wallet/signing"
+	"github.com/cosmos/btcutil/bech32"
 	"golang.org/x/crypto/ripemd160"
 
 	"github.com/Kong/go-pdk"
@@ -146,11 +146,14 @@ func verifyAddress(addr string, pubKey string, kong *pdk.PDK) bool {
 	hrp := addr[0:separator]
 
 	keyB64 := strings.Split(pubKey, ",")[0]
-	keyBytes, err := base64.RawURLEncoding.DecodeString(keyB64)
+	var keyBytes, err = base64.RawStdEncoding.DecodeString(keyB64)
 
 	if err != nil {
-		kong.Log.Err("Could not decode public key")
-		return false
+		keyBytes, err = base64.RawURLEncoding.DecodeString(keyB64)
+		if err != nil {
+			kong.Log.Err("Could not decode public key")
+			return false
+		}
 	}
 
 	hash160Bytes := Hash160(keyBytes)

--- a/signing/signing.go
+++ b/signing/signing.go
@@ -39,9 +39,12 @@ func ParseKey(kong *pdk.PDK) func(token *jwt.Token) (interface{}, error) {
 			return nil, fmt.Errorf("no subject")
 		}
 		keyB64 := strings.Split(sub, ",")[0]
-		keyBytes, err := base64.RawURLEncoding.DecodeString(keyB64)
+		var keyBytes, err = base64.RawStdEncoding.DecodeString(keyB64)
 		if err != nil {
-			return nil, err
+			keyBytes, err = base64.RawURLEncoding.DecodeString(keyB64)
+			if err != nil {
+				return nil, err
+			}
 		}
 		pubk, err := secp256k1.ParsePubKey(keyBytes, secp256k1.S256())
 		if err != nil {


### PR DESCRIPTION
this allows either encoding of the public key claim, with the intent to standardize on non-url encoded claim a la walletconnect in the near future